### PR TITLE
fixed garbled output with println

### DIFF
--- a/lcdi2c.js
+++ b/lcdi2c.js
@@ -219,7 +219,8 @@ LCD.prototype.println = function ( str, line ) {
 
 		//Set cursor to correct line.
 		if ( line > 0 && line <= this.rows ) {
-            this.write( LCD.LINEADDRESS[line], displayPorts.CMD );
+			this.write( LCD.LINEADDRESS[line], displayPorts.CMD );
+			this._sleep(2);
 		};
 
 		this.print( str.substring(0, this.cols ) );


### PR DESCRIPTION
I got garbled output on my LCD when using the println function. I noticed a sleep(2) after almost every write operation in the code, but not after selecting the right line in the println function.
I added that line and I have no more garbled output.